### PR TITLE
Permit partials on plugins templates directory: include_theme_partials

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -1,4 +1,4 @@
-all:
+default:
   theme:
     # Disable/Enable theming globally
     enabled:           true

--- a/config/app.yml
+++ b/config/app.yml
@@ -37,6 +37,7 @@ all:
     themes: []
       # my_theme:
       #   layout:   my_theme               # The name of the layout file to use
+      #   templates_ir:   themeMythemePlugin/templates/ # Directory for theme templates
       #   javascripts: [my_file.js]        # Array of javascripts for this theme
       #   stylesheets: [theme_styles.css]  # Array of stylesheets for this theme
       #   enabled: false                   # Enable/disable the theme [default=true]

--- a/config/sfThemePluginConfiguration.class.php
+++ b/config/sfThemePluginConfiguration.class.php
@@ -46,6 +46,9 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
       $themeUser = new sfThemeUser();
       $this->dispatcher->connect('user.method_not_found', array($themeUser, 'listenUserMethodNotFound'));
 
+      // Add listener on template.filter_parameters to add sf_theme var to view
+      $this->dispatcher->connect('template.filter_parameters', array($themeUser, 'filterTemplateParameters'));
+
       // extend the actions class
       $actionObject = new sfThemeActions($this->getThemeController());
       $this->dispatcher->connect('component.method_not_found', array($actionObject, 'listenComponentMethodNotFound'));

--- a/config/sfThemePluginConfiguration.class.php
+++ b/config/sfThemePluginConfiguration.class.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin configuration for the theme plugin
- * 
+ *
  * @package     sfThemePlugin
  * @subpackage  config
  * @author      Ryan Weaver <ryan@thatsquality.com>
@@ -38,7 +38,7 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
     if (sfConfig::get('app_theme_enabled', false))
     {
       $this->dispatcher->connect('context.load_factories', array($this, 'bootstrap'));
-      
+
       // Add a listener on controller.change_action - key to setting correct theme
       $this->dispatcher->connect('controller.change_action', array($this, 'listenControllerChangeAction'));
 
@@ -52,9 +52,13 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
 
       // register the web debug panel
       $this->dispatcher->connect('debug.web.load_panels', array($this, 'listenDebugWebLoadPanels'));
+
+      // loading helpers
+      $this->configuration->loadHelpers(array('Theme', 'I18N'));
+
     }
   }
-  
+
   /**
    * Listens to context.load_factories. Bootstraps the plugin
    */
@@ -62,7 +66,7 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
   {
     // store the context so we can use it for other listeners
     $this->_context = $event->getSubject();
-    
+
     // create the theme manager instance
     $this->_themeManager = sfThemeManager::createInstance($this->_context);
 
@@ -73,7 +77,7 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
   /**
    * Listens to the controller.change_action event to set the correct theme
    * when the action changes
-   * 
+   *
    * @param sfEvent $event The controller.change_action event object
    */
   public function listenControllerChangeAction(sfEvent $event)
@@ -93,7 +97,7 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
       $this->_context,
       array_keys($this->getThemeManager()->getAvailableThemes())
     );
-    
+
     // If we found a theme we should use, set it on the theme manager
     if ($theme)
     {
@@ -103,9 +107,9 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
 
   /**
    * Returns the current sfThemeManager instance for the application
-   * 
+   *
    * The theme manager is loaded automatically on context.load_factories
-   * 
+   *
    * @return sfThemeManager
    */
   public function getThemeManager()
@@ -114,14 +118,14 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
     {
       throw new sfException('No theme manager instance found');
     }
-    
+
     return $this->_themeManager;
   }
 
   /**
    * Returns the theme controller object, which is responsible for figuring
    * out what theme should be used based on a variety of variables
-   * 
+   *
    * @return sfThemeController
    */
   public function getThemeController()
@@ -130,7 +134,7 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
     {
       $this->_themeController = sfThemeController::createInstance();
     }
-    
+
     return $this->_themeController;
   }
 
@@ -143,7 +147,7 @@ class sfThemePluginConfiguration extends sfPluginConfiguration
     {
       $this->_themeToolkit = sfThemeToolkit::createInstance($this->configuration);
     }
-    
+
     return $this->_themeToolkit;
   }
 

--- a/lib/action/sfThemeAction.class.php
+++ b/lib/action/sfThemeAction.class.php
@@ -12,6 +12,7 @@
  */
 class sfThemeActions
 {
+  /*protected $sf_theme; */
 
   /**
    * The action instance that triggered the component.method_not_found event
@@ -61,17 +62,18 @@ class sfThemeActions
   /**
    * Load the given Sympal theme
    *
-   * @param string $name 
+   * @param string $name
+   * @param string $template subtemplate, if any
    * @return void
    */
-  public function loadTheme($name)
+  public function loadTheme($name, $template=false)
   {
     $this->_action
       ->getContext()
       ->getConfiguration()
       ->getPluginConfiguration('sfThemePlugin')
       ->getThemeManager()
-      ->setCurrentTheme($name);
+      ->setCurrentTheme(($template === false) ? $name : "{$name}_{$template}");
   }
 
   /**

--- a/lib/debug/sfThemeWebDebugPanel.class.php
+++ b/lib/debug/sfThemeWebDebugPanel.class.php
@@ -11,7 +11,7 @@ class sfThemeWebDebugPanel extends sfWebDebugPanel
 {
   public function getTitle()
   {
-    return '<img src="/sfThemePlugin/images/theme.png" alt="Theme Management" height="16" width="16" /> themes';
+    return '<img src="'.$this->webDebug->getOption('image_root_path').'/../../../sfThemePlugin/images/theme.png" alt="Theme Management" height="16" width="16" /> themes';
   }
 
   public function getPanelTitle()
@@ -40,7 +40,7 @@ class sfThemeWebDebugPanel extends sfWebDebugPanel
       $content .= sprintf(
         '<h2>
           --> Theme "%s" is currently being used for this session
-          %s
+          [ %s ]
         </h2>',
         $context->getUser()->getCurrentTheme(),
         $this->_getThemeSwitchLink('clear', 'Reset theme')
@@ -66,7 +66,9 @@ class sfThemeWebDebugPanel extends sfWebDebugPanel
         $switch = '<i>url theme changing disabled</i>';
       }
       
-      $panel .= sprintf('<tr><td class="sfWebDebugLogType">%s %s</td><td style="text-align: center">%s</td><td style="text-align: center">%s</td><td style="text-align: center">%s</td></tr>', $themeToggler, $theme, $available, $current, $switch);
+      $theme_description = (isset ($config['description'])) ? $config['description'] : $theme;
+
+      $panel .= sprintf('<tr><td class="sfWebDebugLogType">%s %s</td><td style="text-align: center">%s</td><td style="text-align: center">%s</td><td style="text-align: center">%s</td></tr>', $themeToggler, $theme_description, $available, $current, $switch);
 
       $panel .= sprintf('<tr id="web_debug_details_%s" style="display: none;"><td colspan="4">%s</td></tr>', $theme, self::_arrayToList($config));
     }

--- a/lib/helper/ThemeHelper.php
+++ b/lib/helper/ThemeHelper.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Evaluates and returns a partial.
+ * The syntax is similar to the one of include_partial
+ *
+ * <b>Example:</b>
+ * <code>
+ *  echo get_partial('mypartial', array('myvar' => 12345));
+ * </code>
+ *
+ * @param  string $templateName  partial name
+ * @param  array  $vars          variables to be made accessible to the partial
+ *
+ * @return string result of the partial execution
+ * @see    include_partial
+ */
+function get_theme_partial($templateName, $vars = array())
+{
+  $context = sfContext::getInstance();
+
+  $actionName = '_'.$templateName;
+
+  $class = 'sfThemePartialView';
+  $current_theme =  $context->getConfiguration()
+                            ->getPluginConfiguration('sfThemePlugin')
+                            ->getThemeManager()
+                            ->getCurrentTheme();
+  $view = new $class($context, $current_theme, $actionName, '');
+  $view->setPartialVars(true === sfConfig::get('sf_escaping_strategy') ? sfOutputEscaper::unescape($vars) : $vars);
+
+  return $view->render();
+}
+
+/**
+ * Evaluates and echoes a partial from current theme.
+ * The partial name is composed as follows: 'mypartial'.
+ * The partial file name is _mypartial.php and is looked for in sfTheme??Plugin/templates/.
+ * For a variable to be accessible to the partial, it has to be passed in the second argument.
+ *
+ * <b>Example:</b>
+ * <code>
+ *  include_theme_partial('mypartial', array('myvar' => 12345));
+ * </code>
+ *
+ * @param  string $templateName  partial name
+ * @param  array  $vars          variables to be made accessible to the partial
+ *
+ * @see    get_partial, include_component
+ */
+function include_theme_partial($templateName, $vars = array())
+{
+  echo get_theme_partial($templateName, $vars);
+}
+
+?>

--- a/lib/manager/sfThemeManager.class.php
+++ b/lib/manager/sfThemeManager.class.php
@@ -494,6 +494,18 @@ class sfThemeManager
       }
     }
 
+    // Accept inheritance, until 3 levels
+    for ($i=1;$i<=3;$i++)
+    {
+      foreach ($themes as $key => $themeConfig)
+      {
+        if (isset($themeConfig['inherit']) && isset($themes[$themeConfig['inherit']]))
+        {
+          $themes[$key] = array_merge($themes[$themeConfig['inherit']], $themeConfig);
+        }
+      }
+    }
+
     return new $class($context, $themes, $themeClass);
   }
 }

--- a/lib/user/sfThemeUser.class.php
+++ b/lib/user/sfThemeUser.class.php
@@ -69,12 +69,33 @@ class sfThemeUser
    */
   public function getThemeConfig($name = null, $default = null)
   {
-
     return sfContext::getInstance()
             ->getConfiguration()
             ->getPluginConfiguration('sfThemePlugin')
             ->getThemeManager()
             ->getCurrentThemeObject()->getConfig($name, $default);
   }
+
+  /**
+   * Listens to the template.filter_parameters event
+   *
+   * Adds a few variables to the view
+   *   * sf_theme
+   */
+  public function filterTemplateParameters(sfEvent $event, $parameters)
+  {
+    // Don't override the variable if it's not set
+    if (!isset($parameters['sf_theme']))
+    {
+      $parameters['sf_theme'] = sfContext::getInstance()
+                                  ->getConfiguration()
+                                  ->getPluginConfiguration('sfThemePlugin')
+                                  ->getThemeManager()
+                                  ->getCurrentThemeObject();
+    }
+
+    return $parameters;
+  }
+
 
 }

--- a/lib/user/sfThemeUser.class.php
+++ b/lib/user/sfThemeUser.class.php
@@ -56,4 +56,25 @@ class sfThemeUser
   {
     return $this->_user->getAttribute('current_theme');
   }
+
+  /**
+   * Returns a given config value or default if the config doesn't exist
+   *
+   * You can also return all of the config by not passing any arguments
+   *
+   * @param string $name    The name of the config
+   * @param mixed $default  The default to return if the config doesn't exist
+   *
+   * @return mixed
+   */
+  public function getThemeConfig($name = null, $default = null)
+  {
+
+    return sfContext::getInstance()
+            ->getConfiguration()
+            ->getPluginConfiguration('sfThemePlugin')
+            ->getThemeManager()
+            ->getCurrentThemeObject()->getConfig($name, $default);
+  }
+
 }

--- a/lib/view/sfThemePartialView.class.php
+++ b/lib/view/sfThemePartialView.class.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the symfony package.
+ * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * A View to render partials in a sfTheme.
+ *
+ * @package    symfony
+ * @subpackage view
+ * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
+ * @version    SVN: $Id: sfPartialView.class.php 23985 2009-11-15 20:09:20Z FabianLange $
+ */
+class sfThemePartialView extends sfPartialView
+{
+
+  /**
+   * Configures template for this view.
+   */
+  public function configure()
+  {
+    $this->setDecorator(false);
+    $this->setTemplate($this->actionName.$this->getExtension());
+
+    $template_dir = sfConfig::get('sf_plugins_dir') . DIRECTORY_SEPARATOR .
+                    $this->context->getConfiguration()
+                      ->getPluginConfiguration('sfThemePlugin')
+                      ->getThemeManager()
+                      ->getCurrentThemeObject()
+                      ->getConfig('templates_dir', 'sfThemePlugin/templates/');
+    $this->setDirectory($template_dir);
+  }
+
+}


### PR DESCRIPTION
Hello, Ryan,

I have created a wordpress theme "clone", as you can see on (watch sample images on bottom):

http://github.com/rafaelgou/themeTwentytenPlugin

Basead on sfThemePlugin. But, for this, I need to include partials in plugins template, for better isolation of the theme.

Well, with a little effort it was possible. You can see the result on the plugin above, and if you think is usefull you could accept this pull.

In time, why don't ask to exclude the sfThemePlugin parked on symfony plugins? It would be nice to do something like:

./symfony plugin:install sfThemePlugin

and install themes like:

./symfony plugin:install themeTwentytenPlugin
./symfony plugin:install themeBluprintPlugin (soon coming)

Or, in other hand, just rename and publish sfThemePlugin as sfThemerPlugin or something like that. 

So symfony comunity would have a good themer for 1.4 version

Thanks!

Rafael Goulart from Brazil
